### PR TITLE
INVALID_LOGIN During Deployment

### DIFF
--- a/support/app/controllers/org_connection_controller.rb
+++ b/support/app/controllers/org_connection_controller.rb
@@ -72,7 +72,7 @@ class OrgConnectionController < ApplicationController
     begin
       pconfig = MavensMate.get_project_config
       pconfig['org_connections'].each do |connection| 
-        pw = KeyChain::find_internet_password("#{pconfig['project_name']}-mm-#{connection['name']}")
+        pw = KeyChain::find_internet_password("#{pconfig['project_name']}-mm-#{connection['username']}")
         connections.push({
           :un => connection["username"], 
           :pw => pw

--- a/support/lib/mavensmate.rb
+++ b/support/lib/mavensmate.rb
@@ -787,7 +787,7 @@ module MavensMate
     begin
       pconfig = MavensMate.get_project_config
       pconfig['org_connections'].each do |connection| 
-        pw = KeyChain::find_internet_password("#{pconfig['project_name']}-mm-#{connection['name']}")
+        pw = KeyChain::find_internet_password("#{pconfig['project_name']}-mm-#{connection['username']}")
         connections.push({
           :un => connection["username"], 
           :pw => pw


### PR DESCRIPTION
Assuming in your `config/settings.yaml` (in your project) there are two settings per org_connection:
- `username` and `environment`

then this could be a possible fix for #84
