### PR TITLE
Added Timestamp to debug log output

### DIFF
--- a/util.py
+++ b/util.py
@@ -139,8 +139,9 @@ def mm_call(operation, mm_debug_panel=True, **kwargs):
     elif operation == 'index_apex':
         message = 'Indexing Project Apex Metadata.'  
         
+    debugTimestamp = time.strftime("%a, %d %b %Y %H:%M:%S", time.localtime())
     if mm_debug_panel:
-        printer.write('\n'+message+'\n')
+        printer.write('\n'+debugTimestamp+':\n'+message+'\n')
 
     threads = []
     thread = MavensMateTerminalCall(


### PR DESCRIPTION
Joe, et.all,

I've often wanted a timestamp on mm actions and it seemed like a good first place to start on the python side of MM. Here's a pull request that just adds a simple date/time stamp to the debug panel's output. 

For example:
Thu, 18 Jul 2013 11:39:36:
Compiling => /Users/awesomeUsernameHidden/Documents/mavensmate/Mulligan/src/classes/mulliganController.cls
............................
[Operation completed Successfully]
