### PR TITLE
Custom templates shown in settings

### DIFF
--- a/mavensmate.sublime-settings
+++ b/mavensmate.sublime-settings
@@ -145,7 +145,9 @@ To override default MavensMate settings, modify user-specific settings (MavensMa
 	        }
     },
 
-    //the location for user custom templates. If the value does not match a valid path, the default value will be a folder named "templates" in the mm_workspace directory
+    //the location for user custom templates. 
+    //If the value does not match a valid path, the default value will be a folder named "templates" in the mm_workspace directory
+    //for example: "/Users/username/Documents/templates" (notice the absolute path and ability to place in any folder)
 	"mm_apex_templates_dir" : "",
 
 	//uncomment a line to supply your own template in the templates directory, or add a new one


### PR DESCRIPTION
Ability to specify directory for custom templates existed, but default
settings has not shown it. Note: Adding custom templates to MavensMate
repository as well.
