### PR TITLE
MavensMate -> Settings -> Project broken under windows

### DIFF
--- a/mavensmate.py
+++ b/mavensmate.py
@@ -337,7 +337,7 @@ class CleanProjectCommand(sublime_plugin.WindowCommand):
 class OpenProjectSettingsCommand(sublime_plugin.WindowCommand):
     def run(self):
         path = os.path.join(util.mm_project_directory(),util.get_project_name()+'.sublime-settings')
-        sublime.active_window().run_command('open_file', {'file': path})
+        sublime.active_window().open_file(path)
 
     def is_enabled(command):
         return util.is_mm_project()      


### PR DESCRIPTION
Project Settings do not open properly in windows from the menu, launching an empty file instead of the correct one. Switch to open_file method simplest way to resolve. Tested mac + win

closes #418, #433 
