### PR TITLE
Bug Fix: Linux - Cannot open project #219

### DIFF
--- a/mavensmate.py
+++ b/mavensmate.py
@@ -413,7 +413,7 @@ class OpenProjectCommand(sublime_plugin.WindowCommand):
                 subprocess.Popen("'/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl' --project '"+project_file_location+"'", stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
         elif 'linux' in sys.platform:
             subl_location = settings.get('mm_subl_location', '/usr/local/bin/subl')
-            subprocess.Popen("'{0}' --project '"+project_file_location+"'".format(subl_location), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
+            subprocess.Popen([subl_location,'--project',project_file_location], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         else:
             subl_location = settings.get('mm_windows_subl_location', '/usr/local/bin/subl')
             if not os.path.isfile(subl_location) and "x86" not in subl_location:


### PR DESCRIPTION
This is a fix for the bug #219 (https://github.com/joeferraro/MavensMate-SublimeText/issues/219). The popen command was not passed the parameters in the correct order so the command would fail to execute. This would have been noticed immediately if the application had been tested on Linux. Also, popen takes a list of arguments as the first parameter which is handled better than passing in one single string.
