### PR TITLE
Fixed json parse issue

### DIFF
--- a/lib/mm_interface.py
+++ b/lib/mm_interface.py
@@ -285,7 +285,7 @@ class MavensMateTerminalCall(threading.Thread):
                 #osx, linux
                 debug('executing mm terminal call:')
                 debug("{0} {1} {2}".format(python_path, pipes.quote(mm_loc), self.get_arguments()))
-                process = subprocess.Popen('\'{0}\' \'{1}\' {2}'.format(python_path, mm_loc, self.get_arguments()), stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
+                process = subprocess.Popen('\'{0}\' \'{1}\' {2}'.format(python_path, mm_loc, self.get_arguments()), stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=none, shell=True)
             else:
                 #windows
                 if self.settings.get('mm_debug_mode', False):


### PR DESCRIPTION
I ran into an issue where python was giving a warning. This warning was getting added into the json response because stderr was piped to stdout. I removed stderr and now it parses json correctly. The better approach would be to handle stderr separately and add it's output to the log file.

By the way python was giving the following warning: /usr/lib/python2.7/dist-packages/gobject/constants.py:24: Warning: g_boxed_type_register_static: assertion 'g_type_from_name (name) == 0' failed
