### PR TITLE
Matching additional SOQL clauses

### DIFF
--- a/sublime/lang/Apex.tmLanguage
+++ b/sublime/lang/Apex.tmLanguage
@@ -552,7 +552,7 @@
                     	</dict>
                     	<dict>
                     		<key>match</key>
-	                    	<string>\b(?i:SELECT|FROM|WHERE|OR|AND|LIKE|CONTAINS|ORDER BY)\b</string>
+	                    	<string>\b(?i:SELECT|FROM|WHERE|OR|AND|LIKE|CONTAINS|ORDER BY|TYPEOF|USING|WITH|GROUP BY|HAVING|LIMIT|OFFSET|FOR REFERENCE|FOR VIEW|UPDATE TRACKING|UPDATE VIEWSTAT)\b</string>
 	                    	<key>name</key>
 	                    	<string>variable.language.java.soql</string>
                     	</dict>


### PR DESCRIPTION
This pull will match extra attributes in SOQL queries, according to Salesforce Documentation.

`TYPEOF|USING|WITH|GROUP BY|HAVING|LIMIT|OFFSET|FOR REFERENCE|FOR VIEW|UPDATE TRACKING|UPDATE VIEWSTATE`