### PR TITLE
Changing keymappings to avoid conflict with Sublime default for duplicate line

### DIFF
--- a/sublime/keymaps/Default (Linux).sublime-keymap
+++ b/sublime/keymaps/Default (Linux).sublime-keymap
@@ -1,4 +1,4 @@
-[  
+[
     {  "keys": ["ctrl+shift+m"], "command": "new_project" },
     {  "keys": ["ctrl+shift+s"], "command": "compile_active_file" },
     {  "keys": ["ctrl+shift+n"], "command": "new_metadata" },
@@ -7,5 +7,5 @@
     {  "keys": ["super+shift+,"], "command": "open_file", "args": {"file": "${packages}/User/mavensmate.sublime-settings"} },
     {  "keys": ["super+shift+."], "command": "open_file", "args": {"file": "${packages}/MavensMate/mavensmate.sublime-settings"} },
     {  "keys": ["super+shift+m"], "command": "show_debug_panel" },
-    {  "keys": ["super+shift+d"], "command": "compile_tabs" }
-]  
+    {  "keys": ["super+shift+s"], "command": "compile_tabs" }
+]

--- a/sublime/keymaps/Default (OSX).sublime-keymap
+++ b/sublime/keymaps/Default (OSX).sublime-keymap
@@ -1,4 +1,4 @@
-[  
+[
     {  "keys": ["ctrl+shift+m"], "command": "new_project" },
     {  "keys": ["ctrl+shift+s"], "command": "compile_active_file" },
     {  "keys": ["ctrl+shift+n"], "command": "new_metadata" },
@@ -7,10 +7,10 @@
     {  "keys": ["super+shift+,"], "command": "open_file", "args": {"file": "${packages}/User/mavensmate.sublime-settings"} },
     {  "keys": ["super+shift+."], "command": "open_file", "args": {"file": "${packages}/MavensMate/mavensmate.sublime-settings"} },
     {  "keys": ["super+shift+m"], "command": "show_debug_panel" },
-    {  "keys": ["super+shift+d"], "command": "compile_tabs" },
+    {  "keys": ["super+shift+s"], "command": "compile_tabs" },
     {  "keys": ["ctrl+shift+x"], "command": "run_apex_script" },
     {  "keys": ["ctrl+shift+a"], "command": "run_async_apex_tests" },
     {  "keys": ["ctrl+shift+l"], "command": "new_quick_log" },
     {  "keys": ["ctrl+shift+k"], "command": "fetch_logs" },
     {  "keys": ["ctrl+shift+,"], "command": "open_project_settings" }
-]  
+]

--- a/sublime/keymaps/Default (Windows).sublime-keymap
+++ b/sublime/keymaps/Default (Windows).sublime-keymap
@@ -1,4 +1,4 @@
-[  
+[
     {  "keys": ["ctrl+shift+m"], "command": "new_project" },
     {  "keys": ["ctrl+shift+s"], "command": "compile_active_file" },
     {  "keys": ["ctrl+shift+n"], "command": "new_metadata" },
@@ -7,5 +7,5 @@
     {  "keys": ["super+shift+,"], "command": "open_file", "args": {"file": "${packages}/User/mavensmate.sublime-settings"} },
     {  "keys": ["super+shift+."], "command": "open_file", "args": {"file": "${packages}/MavensMate/mavensmate.sublime-settings"} },
     {  "keys": ["super+shift+m"], "command": "show_debug_panel" },
-    {  "keys": ["super+shift+d"], "command": "compile_tabs" }
+    {  "keys": ["super+shift+s"], "command": "compile_tabs" }
 ]


### PR DESCRIPTION
Changing default keymapping for compile_tabs to:
super+shift+s for all platforms. Thus removing conflict with
default Sublime keymapping for duplicate line.