### PR TITLE
Addition of the Lightning component markup file extension to deploy on save

### DIFF
--- a/mavensmate.sublime-settings
+++ b/mavensmate.sublime-settings
@@ -177,7 +177,8 @@ To override default MavensMate settings, modify user-specific settings (MavensMa
 		".auradoc",
 		".css",
 		".js",
-		".evt"
+		".evt",
+		".cmp"
 	],
 
 	//template location, e.g. "remote" or "local" ("remote" refers to templates located on github)


### PR DESCRIPTION
.cmp file extension addition to enable markup deploy on save for Lightning components