### PR TITLE
Issue #568 - Apex syntax highlighting on 'global' keyword

### DIFF
--- a/sublime/lang/Apex.tmLanguage
+++ b/sublime/lang/Apex.tmLanguage
@@ -1169,7 +1169,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>\b(public|private|protected|static|final|native|synchronized|abstract|threadsafe|transient)\b</string>
+			<string>\b(global|public|private|protected|static|final|native|synchronized|abstract|threadsafe|transient)\b</string>
 		</dict>
 		<key>strings</key>
 		<dict>


### PR DESCRIPTION
Hello! This is a fantastic plugin, thanks so much! I would like to propose the `global` keyword for synax highlighting. I also found that this was already listed as open issue https://github.com/joeferraro/MavensMate-SublimeText/issues/568.

Thanks!