### PR TITLE
The path of windows is wrong for maven mate exe

### DIFF
--- a/mavensmate.sublime-settings
+++ b/mavensmate.sublime-settings
@@ -45,7 +45,7 @@ To override default MavensMate settings, modify user-specific settings (MavensMa
 	// set to full path of MavensMate-app (MavensMate.app on OSX, MavensMate.exe on Windows, etc.)
 	"mm_mavensmate_app_location" : {
 		"osx": "/Applications/MavensMate.app",
-		"windows": "C:\\Program Files\\MavensMate.exe",
+		"windows": "C:\\Program Files\\MavensMate\\MavensMate.exe",
 		"linux": ""
 	},
 


### PR DESCRIPTION
And for windows 32 bits it must be but I'm not sure how to change that for working for both version : "C:\\Program Files (x86)\\MavensMate\\MavensMate.exe".