### PR TITLE
Changed position for test result summary

### DIFF
--- a/lib/response_handler.py
+++ b/lib/response_handler.py
@@ -510,16 +510,7 @@ class MavensMateResponseHandler(object):
             debug(test_class_name)
             debug(self.response['result']['testResults'][test_class_name])
 
-            test_result = self.response['result']['testResults'][test_class_name]
-            tests_passed_vs_failed = test_result['ExtendedStatus']
-
-            tests_passed_vs_failed = tests_passed_vs_failed.replace('(', '').replace(')','')
-            if tests_passed_vs_failed.split('/')[0] != tests_passed_vs_failed.split('/')[1]:
-                msg += '[TEST RESULT]: FAIL'
-            else:
-                msg += '[TEST RESULT]: PASS'
-
-            msg += '\n\n' + test_class_name + ': ' + test_result['ExtendedStatus'] + ' Passed'
+            
 
             for r in test_result['results']:
                 msg += '\n\n METHOD RESULT \n'
@@ -537,5 +528,16 @@ class MavensMateResponseHandler(object):
                     msg += "\n"
                     msg += r["Message"]
                     msg += "\n"
+
+            test_result = self.response['result']['testResults'][test_class_name]
+            tests_passed_vs_failed = test_result['ExtendedStatus']
+
+            tests_passed_vs_failed = tests_passed_vs_failed.replace('(', '').replace(')','')
+            if tests_passed_vs_failed.split('/')[0] != tests_passed_vs_failed.split('/')[1]:
+                msg += '\n\n[TEST RESULT]: FAIL'
+            else:
+                msg += '\n\n[TEST RESULT]: PASS'
+
+            msg += '\n' + test_class_name + ': ' + test_result['ExtendedStatus'] + ' Passed'
 
         self.__print_to_panel(msg)


### PR DESCRIPTION
The amount of failed/passed tests should be shown after the name of the
tests, so the developer doesn't need to scroll up to see the result.